### PR TITLE
Run EnergyPlus without an intermediate shell

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ __Bugfixes__
 - **Breaking change**: Prevent possible error if HPWH in confined space with very small containment volume; minimum allowed volume now 32 ft3.
 - **Breaking change**: HPWH `EnergyFactor`/`UniformEnergyFactor` must now be >= 1.45 (previously > 1).
 - Fixes ERV supply outlet enthalpy calculation used to calculate latent effectiveness.
+- Runs EnergyPlus without an intermediate shell, fixing failures for weather file paths containing shell metacharacters (and allowing use in shell-less containers).
 - Removes duplicated ceiling/floor internal mass surfaces between conditioned stories.
 - Fixes error if `NumberofBedrooms=0` and `NumberofBathrooms` is omitted.
 

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxml_to_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>5116048e-a294-48a6-9d6e-0176fe080069</version_id>
-  <version_modified>2026-07-20T20:17:08Z</version_modified>
+  <version_id>15cca7f1-c34c-457a-a133-093fa246d06a</version_id>
+  <version_modified>2026-07-31T22:37:59Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLToOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -475,7 +475,7 @@
       <filename>meta_measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>E7E79C68</checksum>
+      <checksum>3882AF20</checksum>
     </file>
     <file>
       <filename>minitest_helper.rb</filename>

--- a/HPXMLtoOpenStudio/resources/meta_measure.rb
+++ b/HPXMLtoOpenStudio/resources/meta_measure.rb
@@ -113,15 +113,16 @@ def run_hpxml_workflow(rundir, measures, measures_dir, debug: false, run_measure
   print "Running simulation...\n" unless suppress_print
   ep_path = File.absolute_path(File.join(OpenStudio.getOpenStudioCLI.to_s, '..', '..', 'EnergyPlus', 'energyplus')) # getEnergyPlusDirectory can be unreliable, using getOpenStudioCLI instead
   simulation_start = Time.now
-  command = "\"#{ep_path}\" -w \"#{model.getWeatherFile.path.get}\" #{ep_input_filename}"
+  # Passed to system() in argv form below, so the path is not shell-interpreted
+  command = [ep_path, '-w', model.getWeatherFile.path.get.to_s, ep_input_filename]
   if debug
     File.open(File.join(rundir, 'run.log'), 'a') do |f|
-      f << "Executing command '#{command}' from working directory '#{rundir}'.\n"
+      f << "Executing command '#{command.join(' ')}' from working directory '#{rundir}'.\n"
     end
   end
   pwd = Dir.pwd
   Dir.chdir(rundir) do
-    system(command, out: [File.join(rundir, 'stdout-energyplus.log'), 'w'], err: [File.join(rundir, 'stderr-energyplus.log'), 'w'])
+    system(*command, out: [File.join(rundir, 'stdout-energyplus.log'), 'w'], err: [File.join(rundir, 'stderr-energyplus.log'), 'w'])
   end
   Dir.chdir(pwd) # Prevent OS "restoring original_directory" warning
   sim_time = (Time.now - simulation_start).round(1)

--- a/workflow/tests/test_other.rb
+++ b/workflow/tests/test_other.rb
@@ -78,6 +78,53 @@ class WorkflowOtherTest < Minitest::Test
     refute(File.exist? File.join(run_dir, 'eplusout.msgpack'))
   end
 
+  def test_run_simulation_epw_path_with_shell_characters
+    # Check that a weather file path containing shell metacharacters is not
+    # interpreted by a shell
+    rb_path = File.join(File.dirname(__FILE__), '..', 'run_simulation.rb')
+    sample_files_path = File.join(File.dirname(__FILE__), '..', 'sample_files')
+    weather_path = File.join(File.dirname(__FILE__), '..', '..', 'weather')
+
+    # The embedded command creates a 'pwned' file if a shell interprets the path
+    orig_epw_path = File.join(weather_path, 'USA_CO_Denver.Intl.AP.725650_TMY3.epw')
+    shell_chars_epw = 'USA_CO_Denver$(touch pwned).725650_TMY3.epw'
+    shell_chars_epw_path = File.join(weather_path, shell_chars_epw)
+    tmp_hpxml_path = File.join(sample_files_path, 'tmp.xml')
+    run_dir = File.join(sample_files_path, 'run')
+
+    begin
+      FileUtils.cp(orig_epw_path, shell_chars_epw_path)
+
+      hpxml = HPXML.new(hpxml_path: File.join(sample_files_path, 'base.xml'))
+      hpxml.buildings[0].climate_and_risk_zones.weather_station_epw_filepath = shell_chars_epw
+      XMLHelper.write_file(hpxml.to_doc, tmp_hpxml_path)
+
+      # Avoid asserting on stale files from a previous run
+      FileUtils.rm_rf(run_dir)
+
+      command = "\"#{OpenStudio.getOpenStudioCLI}\" \"#{rb_path}\" -x \"#{tmp_hpxml_path}\""
+      system(command, err: File::NULL)
+
+      # Check this weather file was the one actually used
+      hpxml_defaults = HPXML.new(hpxml_path: File.join(run_dir, 'in.xml'))
+      assert_equal(shell_chars_epw, hpxml_defaults.buildings[0].climate_and_risk_zones.weather_station_epw_filepath)
+
+      # Check EnergyPlus ran to completion with it
+      eplusout_err_path = File.join(run_dir, 'eplusout.err')
+      assert(File.exist? eplusout_err_path)
+      assert(File.read(eplusout_err_path).include?('EnergyPlus Completed Successfully'))
+      assert(File.exist? File.join(run_dir, 'results_annual.csv'))
+
+      # Check the embedded command was not executed
+      refute(File.exist? File.join(run_dir, 'pwned'))
+      refute(File.exist? File.join(Dir.pwd, 'pwned'))
+    ensure
+      # Cleanup
+      File.delete(tmp_hpxml_path) if File.exist? tmp_hpxml_path
+      File.delete(shell_chars_epw_path) if File.exist? shell_chars_epw_path
+    end
+  end
+
   def test_run_simulation_ems_debug
     rb_path = File.join(File.dirname(__FILE__), '..', 'run_simulation.rb')
     xml = File.join(File.dirname(__FILE__), '..', 'sample_files', 'base.xml')


### PR DESCRIPTION
## Pull Request Description 
`meta_measure.rb` built the EnergyPlus command as a single string, so
Ruby's `system()` ran it through /bin/sh. Two consequences:

- **Weather file paths containing shell metacharacters were mangled.** The
  path is interpolated inside double quotes, but `$(...)`, backticks and $VAR are still expanded by the shell, so EnergyPlus received a different path than the one on disk and any embedded command substitution executed.

- **The workflow could not run in containers without a shell**, such as
  distroless images. system() fails silently there, returning nil with
  empty stdout/stderr energyplus logs and no error message.

This PR builds the command as an array and "splats" it into `system()` instead, which
exec's EnergyPlus directly. The weather path is passed as a single inert
argument, so the manual quoting is no longer needed. Redirection,
working directory and return value semantics are unchanged.

Note the splat is required rather than stylistic: Ruby gives a leading
2-element array the special meaning `[cmdname, argv0]`, so passing the array
unsplatted would misinterpret the first two elements rather than raising.

Adds a workflow test that runs a simulation with a weather file whose
name contains a command substitution, asserting both that EnergyPlus
completes and that the embedded command does not run. It also verifies the weather file under test was the one actually used, so
a future change to weather-file defaulting cannot make the test silently stop
exercising this path. Verified to fail against the unpatched code.

Tested locally against OpenStudio 3.11.0+241b8abb4d (the version CI installs):
`workflow_tests1`, `workflow_tests2` and `unit_tests` all pass — 548 tests,
924,590 assertions, 0 failures — and RuboCop reports no offenses on the changed
files.

## Checklist

Not all may apply:

- [ ] Schematron validator (`EPvalidator.sch`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [x] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
