### PR TITLE
Appliance label warnings

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ __Features__
 - **Breaking change**: For heat pump water heaters, ``HeatingCapacity`` is now *input* rather than *output* capacity, similar to other water heater types.
 - For furnaces/boilers, allows heating efficiency with units of "Percent" as an alternative to "AFUE"; the two units are modeled identically.
 - Updates garage ventilation rate to be SLA=1/150 (same as a vented crawlspace).
+- Adds min/max value warnings for clothes washer and dishwasher label inputs (e.g., `LabelElectricRate` and `LabelGasRate`).
 
 __Bugfixes__
 - **Breaking change**: Prevent possible error if HPWH in confined space with very small containment volume; minimum allowed volume now 32 ft3.

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxml_to_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>e51a1fc6-e456-41f6-83d8-c9582f8874d4</version_id>
-  <version_modified>2026-08-10T18:14:40Z</version_modified>
+  <version_id>f496718b-4a5a-4a7f-8dae-422dd432c852</version_id>
+  <version_modified>2026-08-11T19:47:45Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLToOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -421,7 +421,7 @@
       <filename>hpxml_schematron/EPvalidator.sch</filename>
       <filetype>sch</filetype>
       <usage_type>resource</usage_type>
-      <checksum>72C517F2</checksum>
+      <checksum>A7716640</checksum>
     </file>
     <file>
       <filename>hpxml_schematron/iso-schematron.xsd</filename>
@@ -829,7 +829,7 @@
       <filename>test_validation.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>9202FC56</checksum>
+      <checksum>0AB45B39</checksum>
     </file>
     <file>
       <filename>test_vehicle.rb</filename>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxml_to_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>767757c7-71c2-4fec-bb5c-4ac4fe0c7543</version_id>
-  <version_modified>2026-08-11T21:34:45Z</version_modified>
+  <version_id>674a7d3c-6fb4-4500-acbc-8337a42f2908</version_id>
+  <version_modified>2026-08-11T23:46:38Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLToOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -829,7 +829,7 @@
       <filename>test_validation.rb</filename>
       <filetype>rb</filetype>
       <usage_type>test</usage_type>
-      <checksum>0AB45B39</checksum>
+      <checksum>FBBA37C8</checksum>
     </file>
     <file>
       <filename>test_vehicle.rb</filename>

--- a/HPXMLtoOpenStudio/measure.xml
+++ b/HPXMLtoOpenStudio/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>hpxml_to_openstudio</name>
   <uid>b1543b30-9465-45ff-ba04-1d1f85e763bc</uid>
-  <version_id>f496718b-4a5a-4a7f-8dae-422dd432c852</version_id>
-  <version_modified>2026-08-11T19:47:45Z</version_modified>
+  <version_id>767757c7-71c2-4fec-bb5c-4ac4fe0c7543</version_id>
+  <version_modified>2026-08-11T21:34:45Z</version_modified>
   <xml_checksum>D8922A73</xml_checksum>
   <class_name>HPXMLToOpenStudio</class_name>
   <display_name>HPXML to OpenStudio Translator</display_name>
@@ -421,7 +421,7 @@
       <filename>hpxml_schematron/EPvalidator.sch</filename>
       <filetype>sch</filetype>
       <usage_type>resource</usage_type>
-      <checksum>A7716640</checksum>
+      <checksum>0CCC10E1</checksum>
     </file>
     <file>
       <filename>hpxml_schematron/iso-schematron.xsd</filename>

--- a/HPXMLtoOpenStudio/resources/hpxml_schematron/EPvalidator.sch
+++ b/HPXMLtoOpenStudio/resources/hpxml_schematron/EPvalidator.sch
@@ -2466,6 +2466,12 @@
       <sch:assert role='ERROR' test='count(h:LabelAnnualGasCost) = 1'>Expected LabelAnnualGasCost</sch:assert>
       <sch:assert role='ERROR' test='count(h:LabelUsage) = 1'>Expected LabelUsage</sch:assert>
       <sch:assert role='ERROR' test='count(h:Capacity) = 1'>Expected Capacity</sch:assert>
+      <!-- Warnings -->
+      <sch:report role='WARN' test='number(h:LabelElectricRate) &gt;= 0.5'>LabelElectricRate should typically be less than 0.5.</sch:report>
+      <sch:report role='ERROR' test='number(h:LabelGasRate) &lt;= 0.5'>LabelGasRate should typically be greater than 0.5.</sch:report>
+      <sch:report role='ERROR' test='number(h:LabelGasRate) &gt;= 5'>LabelGasRate should typically be less than 5.</sch:report>
+      <sch:report role='ERROR' test='number(h:LabelAnnualGasCost) &lt;= 5'>LabelAnnualGasCost should typically be greater than 5.</sch:report>
+      <sch:report role='ERROR' test='number(h:LabelUsage) &gt;= 20'>LabelUsage should typically be less than 20.</sch:report>
     </sch:rule>
   </sch:pattern>
 
@@ -2523,6 +2529,12 @@
       <sch:assert role='ERROR' test='count(h:LabelAnnualGasCost) = 1'>Expected LabelAnnualGasCost</sch:assert>
       <sch:assert role='ERROR' test='count(h:LabelUsage) = 1'>Expected LabelUsage</sch:assert>
       <sch:assert role='ERROR' test='count(h:PlaceSettingCapacity) = 1'>Expected PlaceSettingCapacity</sch:assert>
+      <!-- Warnings -->
+      <sch:report role='WARN' test='number(h:LabelElectricRate) &gt;= 0.5'>LabelElectricRate should typically be less than 0.5.</sch:report>
+      <sch:report role='ERROR' test='number(h:LabelGasRate) &lt;= 0.5'>LabelGasRate should typically be greater than 0.5.</sch:report>
+      <sch:report role='ERROR' test='number(h:LabelGasRate) &gt;= 5'>LabelGasRate should typically be less than 5.</sch:report>
+      <sch:report role='ERROR' test='number(h:LabelAnnualGasCost) &lt;= 5'>LabelAnnualGasCost should typically be greater than 5.</sch:report>
+      <sch:report role='ERROR' test='number(h:LabelUsage) &gt;= 20'>LabelUsage should typically be less than 20.</sch:report>
     </sch:rule>
   </sch:pattern>
 

--- a/HPXMLtoOpenStudio/resources/hpxml_schematron/EPvalidator.sch
+++ b/HPXMLtoOpenStudio/resources/hpxml_schematron/EPvalidator.sch
@@ -2468,10 +2468,10 @@
       <sch:assert role='ERROR' test='count(h:Capacity) = 1'>Expected Capacity</sch:assert>
       <!-- Warnings -->
       <sch:report role='WARN' test='number(h:LabelElectricRate) &gt;= 0.5'>LabelElectricRate should typically be less than 0.5.</sch:report>
-      <sch:report role='ERROR' test='number(h:LabelGasRate) &lt;= 0.5'>LabelGasRate should typically be greater than 0.5.</sch:report>
-      <sch:report role='ERROR' test='number(h:LabelGasRate) &gt;= 5'>LabelGasRate should typically be less than 5.</sch:report>
-      <sch:report role='ERROR' test='number(h:LabelAnnualGasCost) &lt;= 5'>LabelAnnualGasCost should typically be greater than 5.</sch:report>
-      <sch:report role='ERROR' test='number(h:LabelUsage) &gt;= 20'>LabelUsage should typically be less than 20.</sch:report>
+      <sch:report role='WARN' test='number(h:LabelGasRate) &lt;= 0.5'>LabelGasRate should typically be greater than 0.5.</sch:report>
+      <sch:report role='WARN' test='number(h:LabelGasRate) &gt;= 5'>LabelGasRate should typically be less than 5.</sch:report>
+      <sch:report role='WARN' test='number(h:LabelAnnualGasCost) &lt;= 5'>LabelAnnualGasCost should typically be greater than 5.</sch:report>
+      <sch:report role='WARN' test='number(h:LabelUsage) &gt;= 20'>LabelUsage should typically be less than 20.</sch:report>
     </sch:rule>
   </sch:pattern>
 
@@ -2531,10 +2531,10 @@
       <sch:assert role='ERROR' test='count(h:PlaceSettingCapacity) = 1'>Expected PlaceSettingCapacity</sch:assert>
       <!-- Warnings -->
       <sch:report role='WARN' test='number(h:LabelElectricRate) &gt;= 0.5'>LabelElectricRate should typically be less than 0.5.</sch:report>
-      <sch:report role='ERROR' test='number(h:LabelGasRate) &lt;= 0.5'>LabelGasRate should typically be greater than 0.5.</sch:report>
-      <sch:report role='ERROR' test='number(h:LabelGasRate) &gt;= 5'>LabelGasRate should typically be less than 5.</sch:report>
-      <sch:report role='ERROR' test='number(h:LabelAnnualGasCost) &lt;= 5'>LabelAnnualGasCost should typically be greater than 5.</sch:report>
-      <sch:report role='ERROR' test='number(h:LabelUsage) &gt;= 20'>LabelUsage should typically be less than 20.</sch:report>
+      <sch:report role='WARN' test='number(h:LabelGasRate) &lt;= 0.5'>LabelGasRate should typically be greater than 0.5.</sch:report>
+      <sch:report role='WARN' test='number(h:LabelGasRate) &gt;= 5'>LabelGasRate should typically be less than 5.</sch:report>
+      <sch:report role='WARN' test='number(h:LabelAnnualGasCost) &lt;= 5'>LabelAnnualGasCost should typically be greater than 5.</sch:report>
+      <sch:report role='WARN' test='number(h:LabelUsage) &gt;= 20'>LabelUsage should typically be less than 20.</sch:report>
     </sch:rule>
   </sch:pattern>
 

--- a/HPXMLtoOpenStudio/tests/test_validation.rb
+++ b/HPXMLtoOpenStudio/tests/test_validation.rb
@@ -984,7 +984,15 @@ class HPXMLtoOpenStudioValidationTest < Minitest::Test
   # Test warnings are correctly triggered during the XSD schema or Schematron validation
   def test_schema_schematron_warning_messages
     # Test case => Warning message(s)
-    all_expected_warnings = { 'battery-pv-output-power-low' => ['Max power output should typically be greater than or equal to 500 W.',
+    all_expected_warnings = { 'appliance-energyguide-label-inputs' => ['LabelElectricRate should typically be less than 0.5. [context: /HPXML/Building/BuildingDetails/Appliances/ClothesWasher[IntegratedModifiedEnergyFactor | ModifiedEnergyFactor], id: "ClothesWasher1"]',
+                                                                       'LabelGasRate should typically be greater than 0.5. [context: /HPXML/Building/BuildingDetails/Appliances/ClothesWasher[IntegratedModifiedEnergyFactor | ModifiedEnergyFactor], id: "ClothesWasher1"]',
+                                                                       'LabelAnnualGasCost should typically be greater than 5. [context: /HPXML/Building/BuildingDetails/Appliances/ClothesWasher[IntegratedModifiedEnergyFactor | ModifiedEnergyFactor], id: "ClothesWasher1"]',
+                                                                       'LabelUsage should typically be less than 20. [context: /HPXML/Building/BuildingDetails/Appliances/ClothesWasher[IntegratedModifiedEnergyFactor | ModifiedEnergyFactor], id: "ClothesWasher1"]',
+                                                                       'LabelElectricRate should typically be less than 0.5. [context: /HPXML/Building/BuildingDetails/Appliances/Dishwasher[RatedAnnualkWh | EnergyFactor], id: "Dishwasher1"]',
+                                                                       'LabelGasRate should typically be greater than 0.5. [context: /HPXML/Building/BuildingDetails/Appliances/Dishwasher[RatedAnnualkWh | EnergyFactor], id: "Dishwasher1"]',
+                                                                       'LabelAnnualGasCost should typically be greater than 5. [context: /HPXML/Building/BuildingDetails/Appliances/Dishwasher[RatedAnnualkWh | EnergyFactor], id: "Dishwasher1"]',
+                                                                       'LabelUsage should typically be less than 20. [context: /HPXML/Building/BuildingDetails/Appliances/Dishwasher[RatedAnnualkWh | EnergyFactor], id: "Dishwasher1"]'],
+                              'battery-pv-output-power-low' => ['Max power output should typically be greater than or equal to 500 W.',
                                                                 'Max power output should typically be greater than or equal to 500 W.',
                                                                 'Rated power output should typically be greater than or equal to 1000 W.'],
                               'dhw-capacities-low' => ['Heating capacity should typically be greater than or equal to 1000 Btu/hr.',
@@ -1071,6 +1079,16 @@ class HPXMLtoOpenStudioValidationTest < Minitest::Test
       puts "[#{i + 1}/#{all_expected_warnings.size}] Testing #{warning_case}..."
       # Create HPXML object
       case warning_case
+      when 'appliance-energyguide-label-inputs'
+        hpxml, hpxml_bldg = _create_hpxml('base.xml')
+        hpxml_bldg.clothes_washers[0].label_electric_rate = 1.1
+        hpxml_bldg.clothes_washers[0].label_gas_rate = 0.1
+        hpxml_bldg.clothes_washers[0].label_annual_gas_cost = 1.1
+        hpxml_bldg.clothes_washers[0].label_usage *= 52
+        hpxml_bldg.dishwashers[0].label_electric_rate = 1.1
+        hpxml_bldg.dishwashers[0].label_gas_rate = 0.1
+        hpxml_bldg.dishwashers[0].label_annual_gas_cost = 1.1
+        hpxml_bldg.dishwashers[0].label_usage *= 52
       when 'battery-pv-output-power-low'
         hpxml, hpxml_bldg = _create_hpxml('base-pv-battery.xml')
         hpxml_bldg.batteries[0].rated_power_output = 0.1

--- a/HPXMLtoOpenStudio/tests/test_validation.rb
+++ b/HPXMLtoOpenStudio/tests/test_validation.rb
@@ -992,6 +992,8 @@ class HPXMLtoOpenStudioValidationTest < Minitest::Test
                                                                        'LabelGasRate should typically be greater than 0.5. [context: /HPXML/Building/BuildingDetails/Appliances/Dishwasher[RatedAnnualkWh | EnergyFactor], id: "Dishwasher1"]',
                                                                        'LabelAnnualGasCost should typically be greater than 5. [context: /HPXML/Building/BuildingDetails/Appliances/Dishwasher[RatedAnnualkWh | EnergyFactor], id: "Dishwasher1"]',
                                                                        'LabelUsage should typically be less than 20. [context: /HPXML/Building/BuildingDetails/Appliances/Dishwasher[RatedAnnualkWh | EnergyFactor], id: "Dishwasher1"]'],
+                              'appliance-energyguide-label-inputs2' => ['LabelGasRate should typically be less than 5. [context: /HPXML/Building/BuildingDetails/Appliances/ClothesWasher[IntegratedModifiedEnergyFactor | ModifiedEnergyFactor], id: "ClothesWasher1"]',
+                                                                        'LabelGasRate should typically be less than 5. [context: /HPXML/Building/BuildingDetails/Appliances/Dishwasher[RatedAnnualkWh | EnergyFactor], id: "Dishwasher1"]'],
                               'battery-pv-output-power-low' => ['Max power output should typically be greater than or equal to 500 W.',
                                                                 'Max power output should typically be greater than or equal to 500 W.',
                                                                 'Rated power output should typically be greater than or equal to 1000 W.'],
@@ -1089,6 +1091,10 @@ class HPXMLtoOpenStudioValidationTest < Minitest::Test
         hpxml_bldg.dishwashers[0].label_gas_rate = 0.1
         hpxml_bldg.dishwashers[0].label_annual_gas_cost = 1.1
         hpxml_bldg.dishwashers[0].label_usage *= 52
+      when 'appliance-energyguide-label-inputs2'
+        hpxml, hpxml_bldg = _create_hpxml('base.xml')
+        hpxml_bldg.clothes_washers[0].label_gas_rate = 10.0
+        hpxml_bldg.dishwashers[0].label_gas_rate = 10.0
       when 'battery-pv-output-power-low'
         hpxml, hpxml_bldg = _create_hpxml('base-pv-battery.xml')
         hpxml_bldg.batteries[0].rated_power_output = 0.1


### PR DESCRIPTION
## Pull Request Description

Closes #2251. Adds min/max value warnings for clothes washer and dishwasher label inputs (e.g., `LabelElectricRate` and `LabelGasRate`). Decided to use warnings instead of errors to ensure we don't accidentally limit any real products (today or in the future).

## Checklist

Not all may apply:

- [x] Schematron validator (`EPvalidator.sch`) has been updated
- [ ] Sample files have been added/updated (`openstudio tasks.rb update_hpxmls`)
- [x] Tests have been added/updated (e.g., `HPXMLtoOpenStudio/tests/test*.rb` and/or `workflow/tests/test*.rb`)
- [ ] Documentation has been updated
- [x] Changelog has been updated
- [x] `openstudio tasks.rb update_measures` has been run
- [x] No unexpected changes to simulation results of sample files
